### PR TITLE
fix bug handling local unspec unspec

### DIFF
--- a/lib/nydus.ex
+++ b/lib/nydus.ex
@@ -163,6 +163,12 @@ defmodule Nydus do
     ret
   end
 
+  defp second_receive(%{signature: 2, version: 2, addresses_and_tlvs_length: 0} = state) do
+    addresses_block = ""
+    state = Map.put(state, :sr_bin, addresses_block)
+    {:ok, state}
+  end
+
   defp second_receive(%{signature: 2, version: 2} = state) do
     # Receive the rest of the header.
     case :gen_tcp.recv(state.socket, state.addresses_and_tlvs_length, state.second_timeout) do

--- a/test/nydus_v2_unspec_unspec_test.exs
+++ b/test/nydus_v2_unspec_unspec_test.exs
@@ -1,0 +1,38 @@
+defmodule NydusV2UnspecUnspecTest do
+  use ExUnit.Case
+
+  alias Nydus.V2
+
+  doctest Nydus
+
+  setup do
+    {:ok, server_socket} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+    {:ok, port} = :inet.port(server_socket)
+    {:ok, client_socket} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+    {:ok, server_socket} = :gen_tcp.accept(server_socket)
+
+    %{
+      client_socket: client_socket,
+      server_socket: server_socket,
+      opts: [version_config: 2]
+    }
+  end
+
+  describe "gen_tcp - version_config 2 - ok" do
+    test "local unspec unspec", context do
+      expected = %{
+        address_family: :unspec,
+        addresses_and_tlvs: "",
+        signature: 2,
+        socket_protocol: :unspec,
+        version: 2,
+        command: :local
+      }
+
+      {:ok, header} = V2.encode(expected)
+      :gen_tcp.send(context.client_socket, header)
+      assert {:ok, actual} = Nydus.receive_and_decode(context.server_socket, context.opts)
+      assert expected == actual
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit when experiencing PROXY protocol headers that had had a 0 length addresses block (e.g. when local unspec unspec like for a LB healthcheck) Nydus would errantly return a second receive timeout error. This PR fixes that behaviour such that the header is parsed successfully.